### PR TITLE
Improve username identification in GitHub Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # GitHub Unveiler
 
-A Chrome extension to replace GitHub usernames with display names in references and links on GitHub pages.
+A Chrome extension to replace GitHub usernames with display names in references and links on GitHub pages, including GitHub Projects views.
 
 Available on the Chrome Web Store: https://chromewebstore.google.com/detail/github-unveiler/nepdghlcapkfgnficpnefibalbhjofaa
+
+## Features
+
+- Replaces usernames with display names across GitHub and GitHub Enterprise
+- Works in GitHub Projects views using avatar-based detection for better compatibility
+- Supports multiple GitHub Enterprise versions with different UI implementations
+- Caches display names for improved performance
 
 ## Usage
 

--- a/content.js
+++ b/content.js
@@ -175,9 +175,14 @@
 // Function to update the element directly
 function updateElementDirectly(element, username, displayName) {
   let changed = false;
-  if (element.tagName === 'H3' && element.classList.contains('slicer-items-module__title--EMqA1')) {
-    // updateTextNodes returns true if it made a change
-    changed = updateTextNodes(element, username, displayName);
+  
+  // For h3 elements that contain usernames (found via avatar association)
+  if (element.tagName === 'H3' && element.textContent.trim() === username) {
+    // Only replace if the text exactly matches the username (no partial replacements)
+    if (element.textContent.trim() === username) {
+      element.textContent = displayName;
+      changed = true;
+    }
   } else if (element.tagName === 'IMG' && element.dataset.testid === 'github-avatar') {
     if (element.alt === displayName) return false; // Already updated
     element.alt = displayName;
@@ -190,61 +195,156 @@ function updateElementDirectly(element, username, displayName) {
   return changed;
 }
 
-// Function to process project elements
+// Function to find username text associated with an avatar
+function findUsernameFromAvatar(avatarImg) {
+  // Start from the avatar and traverse up to find the containing item
+  let container = avatarImg.closest('li, div[class*="item"], div[class*="row"], button');
+  if (!container) return null;
+  
+  // Look for h3, span, or div elements that might contain the username
+  // Prioritize h3 tags as they commonly contain the username in project views
+  const possibleUsernameElements = container.querySelectorAll('h3, span[class*="title"], div[class*="title"], span[class*="name"], div[class*="name"]');
+  
+  for (const elem of possibleUsernameElements) {
+    const text = elem.textContent.trim();
+    // Basic validation: usernames are typically alphanumeric with hyphens/underscores
+    // and don't contain spaces (unless it's already a display name)
+    if (text && !text.includes(' ') && /^[a-zA-Z0-9\-_]+$/.test(text)) {
+      return { element: elem, username: text };
+    }
+  }
+  
+  // Fallback: use the alt text of the image itself if it looks like a username
+  const altText = avatarImg.alt.trim();
+  if (altText && altText !== "" && !altText.includes(' ')) {
+    return { element: null, username: altText };
+  }
+  
+  return null;
+}
+
+// Function to process project elements using avatar-based detection
 function processProjectElements(root) {
   if (!(root instanceof Element)) return; // Ensure root is an Element
 
-  const h3Selector = 'h3.slicer-items-module__title--EMqA1';
-  const imgSelector = 'img[data-testid="github-avatar"][alt]';
-  const spanSelector = 'span[aria-label]';
+  // Find all avatar images - this is a stable selector across GitHub versions
+  const avatarSelector = 'img[data-testid="github-avatar"], img[data-component="Avatar"]';
+  
+  let avatarsToProcess = [];
 
-  let elementsToProcess = [];
-
-  // Check if root itself matches any of the selectors
-  if (root.matches(h3Selector) || root.matches(imgSelector) || root.matches(spanSelector)) {
-    elementsToProcess.push(root);
+  // Check if root itself is an avatar
+  if (root.matches(avatarSelector)) {
+    avatarsToProcess.push(root);
   }
 
-  // Add descendants
-  elementsToProcess.push(...Array.from(root.querySelectorAll(`${h3Selector}, ${imgSelector}, ${spanSelector}`)));
+  // Add descendant avatars
+  avatarsToProcess.push(...Array.from(root.querySelectorAll(avatarSelector)));
 
-  // Deduplication is not strictly necessary due to PROCESSED_MARKER, but can be done with a Set if preferred for cleanliness.
-  // elementsToProcess = Array.from(new Set(elementsToProcess));
-
-  elementsToProcess.forEach(element => {
-    if (element.hasAttribute(PROCESSED_MARKER)) return;
-    let username;
-    if (element.matches(h3Selector)) {
-      username = element.textContent.trim();
-    } else if (element.matches(imgSelector)) {
-      username = element.alt.trim();
-      // Remove "@" prefix if present in alt attribute
-      if (username.startsWith('@')) {
-        username = username.substring(1);
-      }
-    } else if (element.matches(spanSelector)) {
-      username = element.getAttribute('aria-label').trim();
-    }
-
-    // Ignore invalid usernames
-    if (!username || username === "No Assignees" || username === "") {
+  avatarsToProcess.forEach(avatarImg => {
+    // Skip if already processed
+    if (avatarImg.hasAttribute(PROCESSED_MARKER)) return;
+    
+    // Skip "No Assignees" or bot avatars
+    const altText = avatarImg.alt || "";
+    if (altText === "No Assignees" || altText === "" || altText.includes('[bot]')) {
       return;
     }
-
+    
+    // Find the username element associated with this avatar
+    const usernameInfo = findUsernameFromAvatar(avatarImg);
+    if (!usernameInfo || !usernameInfo.username) return;
+    
+    const username = usernameInfo.username;
+    
+    // Process the avatar's alt text
     if (displayNames[username]) {
-      const updated = updateElementDirectly(element, username, displayNames[username]);
-      if (updated) {
-        element.setAttribute(PROCESSED_MARKER, 'true');
+      avatarImg.alt = displayNames[username];
+      avatarImg.setAttribute(PROCESSED_MARKER, 'true');
+      
+      // Also update the associated text element if found
+      if (usernameInfo.element && !usernameInfo.element.hasAttribute(PROCESSED_MARKER)) {
+        usernameInfo.element.textContent = displayNames[username];
+        usernameInfo.element.setAttribute(PROCESSED_MARKER, 'true');
       }
     } else {
-      registerElement(username, () => {
-        const updated = updateElementDirectly(element, username, displayNames[username]);
-        if (updated) {
-          element.setAttribute(PROCESSED_MARKER, 'true');
+      // Register callbacks for when the display name is fetched
+      registerElement(username, (displayName) => {
+        avatarImg.alt = displayName;
+        avatarImg.setAttribute(PROCESSED_MARKER, 'true');
+        
+        // Update the associated text element
+        if (usernameInfo.element && !usernameInfo.element.hasAttribute(PROCESSED_MARKER)) {
+          usernameInfo.element.textContent = displayName;
+          usernameInfo.element.setAttribute(PROCESSED_MARKER, 'true');
         }
       });
       fetchDisplayName(username);
     }
+  });
+  
+  // Also process any standalone username elements that might not have avatars
+  // This handles edge cases where usernames appear without avatars
+  processStandaloneUsernames(root);
+}
+
+// Function to process usernames that appear without avatars (edge cases)
+function processStandaloneUsernames(root) {
+  if (!(root instanceof Element)) return;
+  
+  // Look for elements that commonly contain usernames in project views
+  // Use more generic selectors that work across GitHub versions
+  const selectors = [
+    'a[href^="/"][href$=""]:not([href*="/"])', // Direct user profile links
+    'span[aria-label]:not([' + PROCESSED_MARKER + '])', // Spans with aria-labels that might be usernames
+  ];
+  
+  selectors.forEach(selector => {
+    let elements = [];
+    if (root.matches(selector)) {
+      elements.push(root);
+    }
+    elements.push(...Array.from(root.querySelectorAll(selector)));
+    
+    elements.forEach(element => {
+      if (element.hasAttribute(PROCESSED_MARKER)) return;
+      
+      let username = null;
+      
+      // Extract username from href if it's a link
+      if (element.tagName === 'A') {
+        const href = element.getAttribute('href');
+        const match = href.match(/^\/([a-zA-Z0-9\-_]+)$/);
+        if (match) {
+          username = match[1];
+        }
+      } else if (element.hasAttribute('aria-label')) {
+        const label = element.getAttribute('aria-label').trim();
+        if (label && /^[a-zA-Z0-9\-_]+$/.test(label)) {
+          username = label;
+        }
+      }
+      
+      if (!username || username === "No Assignees") return;
+      
+      if (displayNames[username]) {
+        if (element.tagName === 'A') {
+          updateTextNodes(element, username, displayNames[username]);
+        } else if (element.hasAttribute('aria-label')) {
+          element.setAttribute('aria-label', displayNames[username]);
+        }
+        element.setAttribute(PROCESSED_MARKER, 'true');
+      } else {
+        registerElement(username, (displayName) => {
+          if (element.tagName === 'A') {
+            updateTextNodes(element, username, displayName);
+          } else if (element.hasAttribute('aria-label')) {
+            element.setAttribute('aria-label', displayName);
+          }
+          element.setAttribute(PROCESSED_MARKER, 'true');
+        });
+        fetchDisplayName(username);
+      }
+    });
   });
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GitHub Unveiler",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Replaces GitHub usernames with display names in GitHub and GitHub Enterprise instances.",
   "permissions": [
     "scripting",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -346,65 +346,119 @@ describe("content.js", () => {
   });
 
   describe("GitHub Projects Elements", () => {
-    test("should update username in h3.slicer-items-module__title--EMqA1", async () => {
+    test("should update username based on avatar image", async () => {
+      // Create a container that simulates a project item
+      const container = document.createElement("li");
+      
+      // Add an avatar image
+      const img = document.createElement("img");
+      img.setAttribute("data-testid", "github-avatar");
+      img.setAttribute("alt", "projectUser1");
+      container.appendChild(img);
+      
+      // Add an h3 with the username
       const h3 = document.createElement("h3");
-      h3.className = "slicer-items-module__title--EMqA1";
       h3.textContent = "projectUser1";
-      document.body.appendChild(h3);
+      container.appendChild(h3);
+      
+      document.body.appendChild(container);
 
       require("../content.js");
       await flushPromises();
 
+      expect(img.getAttribute("alt")).toBe("Project User One");
       expect(h3.textContent).toBe("Project User One");
+      expect(img.getAttribute('data-ghu-processed')).toBe('true');
       expect(h3.getAttribute('data-ghu-processed')).toBe('true');
     });
 
-    test("should update username in img[data-testid='github-avatar'][alt]", async () => {
+    test("should update avatar alt text and find associated username element", async () => {
+      // Create a more realistic structure with avatar in a container
+      const button = document.createElement("button");
+      
       const img = document.createElement("img");
       img.setAttribute("data-testid", "github-avatar");
       img.setAttribute("alt", "projectUser2");
-      document.body.appendChild(img);
+      button.appendChild(img);
+      
+      // Add a span that contains the username
+      const span = document.createElement("span");
+      span.className = "some-title-class";
+      span.textContent = "projectUser2";
+      button.appendChild(span);
+      
+      document.body.appendChild(button);
 
       require("../content.js");
       await flushPromises();
 
       expect(img.getAttribute("alt")).toBe("Project User Two");
+      expect(span.textContent).toBe("Project User Two");
       expect(img.getAttribute('data-ghu-processed')).toBe('true');
     });
 
-    test("should update username in span[aria-label]", async () => {
-      const span = document.createElement("span");
-      span.setAttribute("aria-label", "projectUser3");
-      document.body.appendChild(span);
+    test("should handle avatars with data-component='Avatar' attribute", async () => {
+      // Test the alternative avatar selector
+      const div = document.createElement("div");
+      div.className = "item-container";
+      
+      const img = document.createElement("img");
+      img.setAttribute("data-component", "Avatar");
+      img.setAttribute("alt", "projectUser3");
+      div.appendChild(img);
+      
+      const h3 = document.createElement("h3");
+      h3.textContent = "projectUser3";
+      div.appendChild(h3);
+      
+      document.body.appendChild(div);
 
       require("../content.js");
       await flushPromises();
 
-      expect(span.getAttribute("aria-label")).toBe("Project User Three");
-      expect(span.getAttribute('data-ghu-processed')).toBe('true');
+      expect(img.getAttribute("alt")).toBe("Project User Three");
+      expect(h3.textContent).toBe("Project User Three");
+      expect(img.getAttribute('data-ghu-processed')).toBe('true');
     });
 
-    test("should update dynamically added project H3 element (MutationObserver)", async () => {
+    test("should update dynamically added project elements with avatars (MutationObserver)", async () => {
       require("../content.js"); // Load content.js first to set up observer
 
+      const container = document.createElement("div");
+      container.className = "project-item";
+      
+      const img = document.createElement("img");
+      img.setAttribute("data-testid", "github-avatar");
+      img.setAttribute("alt", "projectUser1");
+      container.appendChild(img);
+      
       const h3 = document.createElement("h3");
-      h3.className = "slicer-items-module__title--EMqA1";
       h3.textContent = "projectUser1";
-      document.body.appendChild(h3);
+      container.appendChild(h3);
+      
+      document.body.appendChild(container);
 
       await flushPromises();
       // Additional small delay for MutationObserver, similar to existing test
       await new Promise(r => setTimeout(r, 50));
 
+      expect(img.getAttribute("alt")).toBe("Project User One");
       expect(h3.textContent).toBe("Project User One");
-      expect(h3.getAttribute('data-ghu-processed')).toBe('true');
+      expect(img.getAttribute('data-ghu-processed')).toBe('true');
     });
 
     test("should not process 'No Assignees' and not call fetch", async () => {
+      const img = document.createElement("img");
+      img.setAttribute("data-testid", "github-avatar");
+      img.setAttribute("alt", "No Assignees");
+      
       const h3 = document.createElement("h3");
-      h3.className = "slicer-items-module__title--EMqA1";
       h3.textContent = "No Assignees";
-      document.body.appendChild(h3);
+      
+      const container = document.createElement("div");
+      container.appendChild(img);
+      container.appendChild(h3);
+      document.body.appendChild(container);
 
       // Spy on fetch specifically for this test, though it shouldn't be called for "No Assignees"
       const fetchSpy = global.fetch;
@@ -412,8 +466,9 @@ describe("content.js", () => {
       require("../content.js");
       await flushPromises();
 
+      expect(img.getAttribute("alt")).toBe("No Assignees");
       expect(h3.textContent).toBe("No Assignees");
-      expect(h3.hasAttribute('data-ghu-processed')).toBe(false);
+      expect(img.hasAttribute('data-ghu-processed')).toBe(false);
 
       // Check that fetch was not called for "No Assignees"
       // The easiest way is to ensure no call to fetch had '/No%20Assignees' (URL encoded space)
@@ -442,11 +497,19 @@ describe("content.js", () => {
 
   describe("Idempotency and Marker Tests", () => {
     test("data-ghu-processed attribute should prevent re-processing", async () => {
+      const img = document.createElement("img");
+      img.setAttribute("data-testid", "github-avatar");
+      img.setAttribute("alt", "projectUser1");
+      img.setAttribute("data-ghu-processed", "true"); // Mark as already processed
+      
       const h3 = document.createElement("h3");
-      h3.className = "slicer-items-module__title--EMqA1";
       h3.textContent = "projectUser1"; // This would normally be processed
       h3.setAttribute("data-ghu-processed", "true"); // Mark as already processed
-      document.body.appendChild(h3);
+      
+      const container = document.createElement("div");
+      container.appendChild(img);
+      container.appendChild(h3);
+      document.body.appendChild(container);
 
       const fetchSpy = global.fetch;
       const sendMessageSpy = global.chrome.runtime.sendMessage;
@@ -455,6 +518,7 @@ describe("content.js", () => {
       await flushPromises();
 
       // Content should remain unchanged because it was marked as processed
+      expect(img.getAttribute("alt")).toBe("projectUser1");
       expect(h3.textContent).toBe("projectUser1");
 
       // Verify fetch was not called for this user because it was skipped


### PR DESCRIPTION
Refactor GitHub Projects username replacement to use avatar-based detection for improved compatibility across GitHub versions and more accurate replacements.

The previous implementation relied on volatile CSS class names that varied between GitHub Enterprise versions, causing the feature to break. It also indiscriminately replaced any text matching a username, leading to false positives. This PR addresses these issues by using avatar images as a stable anchor to identify user rows and then precisely target the associated username text for replacement.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cabbbc4-6abc-44c7-8a8d-eafd6c48ee6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8cabbbc4-6abc-44c7-8a8d-eafd6c48ee6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

